### PR TITLE
mComponent code for the message queue

### DIFF
--- a/include/lego/msg_q.h
+++ b/include/lego/msg_q.h
@@ -1,0 +1,57 @@
+
+
+#include <lego/list.h>
+#include <lego/spinlock.h>
+
+#ifndef MSG_H
+#define MSG_H
+
+#define MAX_FILENAME_LENGTH 100
+
+/*
+ * return success value for the message queue system call
+ */ 
+#define MSG_RET_SUCCESS 0
+#define MSG_RET_FAIL 1
+/* 
+ * message queue data structure
+ */
+
+struct mc_msg_queue{
+	char* msg_data;
+	unsigned int msg_size;
+	struct list_head list;
+	/* this array is the pid table 
+ 	struct list_head pid_list; */
+};
+
+static DEFINE_SPINLOCK(map_lock);
+
+struct name_mq_map{
+	char mq_name[MAX_FILENAME_LENGTH];
+	unsigned int max_size;
+	struct list_head* mq;
+	struct list_head list;
+	spinlock_t mq_lock;
+};
+
+unsigned int append(char* msg_data, unsigned int msg_size, struct list_head* name_nid_dict);
+
+/* the msg data passed in should copy a new memory here, msg_data should point to a continous memory
+ *  * */
+unsigned int pop(char* msg_data, int* msg_size, struct list_head* name_nid_dict);
+/*
+ *  *  * print name_nid_dict
+ *   *   */
+
+
+void print(struct list_head* name_nid_dict);
+void free_all(struct list_head* name_nid_dict);
+static LIST_HEAD(addr_map);
+
+unsigned int mc_mq_open(char* mq_name, unsigned int max_size);
+unsigned int mc_mq_send(char *mq_name, char* msg_data, unsigned int msg_size);
+unsigned int mc_mq_receive(char *mq_name, char* msg_data, unsigned int* msg_size);
+unsigned int mc_mq_close(char* mq_name);
+unsigned int mc_mq_free(void);
+#endif

--- a/include/lego/msg_q.h
+++ b/include/lego/msg_q.h
@@ -13,6 +13,8 @@
  */ 
 #define MSG_RET_SUCCESS 0
 #define MSG_RET_FAIL 1
+#define MSG_MQ_OPEN_ERROR_ALREADY_EXIST 2
+
 /* 
  * message queue data structure
  */
@@ -21,8 +23,6 @@ struct mc_msg_queue{
 	char* msg_data;
 	unsigned int msg_size;
 	struct list_head list;
-	/* this array is the pid table 
- 	struct list_head pid_list; */
 };
 
 static DEFINE_SPINLOCK(map_lock);
@@ -41,10 +41,6 @@ unsigned int append(char* msg_data, unsigned int msg_size, struct list_head* nam
  * the msg data passed in should copy a new memory here, msg_data should point to a continous memory
  */
 unsigned int pop(char* msg_data, int* msg_size, struct list_head* name_nid_dict);
-/*
- * print name_nid_dict
- */
-
 
 void print(struct list_head* name_nid_dict);
 void free_all(struct list_head* name_nid_dict);

--- a/include/lego/msg_q.h
+++ b/include/lego/msg_q.h
@@ -37,12 +37,13 @@ struct name_mq_map{
 
 unsigned int append(char* msg_data, unsigned int msg_size, struct list_head* name_nid_dict);
 
-/* the msg data passed in should copy a new memory here, msg_data should point to a continous memory
- *  * */
+/* 
+ * the msg data passed in should copy a new memory here, msg_data should point to a continous memory
+ */
 unsigned int pop(char* msg_data, int* msg_size, struct list_head* name_nid_dict);
 /*
- *  *  * print name_nid_dict
- *   *   */
+ * print name_nid_dict
+ */
 
 
 void print(struct list_head* name_nid_dict);

--- a/include/lego/rpc/struct_p2m.h
+++ b/include/lego/rpc/struct_p2m.h
@@ -205,19 +205,19 @@ struct p2m_mqopen_payload{
 	char mq_name[MAX_FILENAME_LENGTH];
 };
 
-/*
+
 void handle_mq_open_request(struct p2m_mqopen_payload* payload, 
 	struct thpool_buffer*tb);
-*/
+
 
 struct p2m_mqclose_payload{
 	char mq_name[MAX_FILENAME_LENGTH];
 };
 
-/*
+
 void handle_mq_close_request(struct p2m_mqclose_payload* payload, 
 	struct thpool_buffer*tb);
-*/
+
 
 
 /* for now we use fixed payload here
@@ -230,10 +230,10 @@ struct p2m_mqsend_payload{
 	char mq_name[MAX_FILENAME_LENGTH];
 };
 
-/*
+
 void handle_mq_send_request(struct p2m_mqsend_payload* payload, 
 	struct thpool_buffer*tb);
-*/
+
 
 
 struct p2m_mqrecv_payload{
@@ -245,10 +245,10 @@ struct p2m_mqrecv_reply_struct {
         char 	mq_data[CONFIG_MAX_MSG_LENGTH];
 };
 
-/*
+
 void handle_mq_receive_request(struct p2m_mqrecv_payload* payload, 
 	struct thpool_buffer*tb);
-*/
+
 
 /*
  * P2M_MMAP

--- a/managers/memory/Makefile
+++ b/managers/memory/Makefile
@@ -9,6 +9,7 @@ obj-y += handle_execve.o
 obj-y += handle_mmap.o
 obj-y += handle_file.o
 obj-y += handle_checkpoint.o
+obj-y += handle_mq.o
 obj-y += file_ops.o
 obj-y += missing_syscalls.o
 obj-y += m2s_read_write.o

--- a/managers/memory/core.c
+++ b/managers/memory/core.c
@@ -20,6 +20,7 @@
 #include <lego/fit_ibapi.h>
 #include <lego/completion.h>
 #include <lego/comp_storage.h>
+#include <lego/msg_q.h>
 
 #include <memory/vm.h>
 #include <memory/pid.h>
@@ -32,6 +33,7 @@
 #include <memory/pgcache.h>
 
 #include <monitor/gmm_handler.h>
+
 
 void handle_bad_request(struct common_header *hdr, u64 desc)
 {
@@ -170,6 +172,23 @@ static void thpool_worker_handler(struct thpool_worker *worker,
 	case P2M_TEST_NOREPLY:
 		__SetThpoolBufferNoreply(buffer);
 		handle_p2m_test_noreply(msg, buffer);
+		break;
+
+/* message queue opcode */
+	case P2M_MQOPEN:
+		handle_mq_open_request(payload,buffer);
+		break;
+
+	case P2M_MQSEND:
+		handle_mq_send_request(payload,buffer);
+		break;
+
+	case P2M_MQRECV:
+		handle_mq_receive_request(payload,buffer);
+		break;
+
+	case P2M_MQCLOSE:
+		handle_mq_close_request(payload,buffer);
 		break;
 
 /* PCACHE */

--- a/managers/memory/handle_mq.c
+++ b/managers/memory/handle_mq.c
@@ -36,7 +36,7 @@ unsigned int append(char* msg_data, unsigned int msg_size, struct list_head* nam
 
 
 /* the msg data passed in should copy a new memory here, msg_data should point to a continous memory
- *  * */
+ */
 unsigned int pop(char* msg_data, int* msg_size, struct list_head* name_nid_dict){
 	struct list_head* next = name_nid_dict->next;
 
@@ -89,7 +89,7 @@ unsigned int mc_mq_open(char* mq_name, unsigned int max_size)
 {
 
 /*
- *what if we already got a message queue with that name in the name map?	
+ * what if we already got a message queue with that name in the name map?	
  */
 	unsigned long flags;
 	spin_lock_irqsave(&map_lock, flags);

--- a/managers/memory/handle_mq.c
+++ b/managers/memory/handle_mq.c
@@ -179,6 +179,10 @@ unsigned int mc_mq_close(char* mq_name){
 unsigned int mc_mq_send(char *mq_name, char* msg_data, unsigned int msg_size){
 
 	/* find out where is our mq head pointer */
+	
+	/* before that, lock map_lock to avoid mq_close to modify the entry 
+ 	 * before we get the target
+	 */
 	unsigned long map_flags;
 	spin_lock_irqsave(&map_lock, map_flags);
 
@@ -209,6 +213,7 @@ unsigned int mc_mq_send(char *mq_name, char* msg_data, unsigned int msg_size){
 
 unsigned int mc_mq_receive(char *mq_name, char* msg_data, unsigned int* msg_size){
 
+	/* same problem with mc_mq_send, close function may cause trouble*/
 	unsigned long map_flags;
 	spin_lock_irqsave(&map_lock, map_flags);
 

--- a/managers/memory/handle_mq.c
+++ b/managers/memory/handle_mq.c
@@ -1,0 +1,301 @@
+#include <lego/list.h>
+#include <lego/msg_q.h>
+#include <lego/stat.h>
+#include <lego/slab.h>
+#include <lego/uaccess.h>
+#include <lego/files.h>
+#include <lego/syscalls.h>
+#include <lego/comp_common.h>
+#include <lego/kernel.h>
+#include <memory/thread_pool.h>
+
+unsigned int append(char* msg_data, unsigned int msg_size, struct list_head* name_nid_dict){
+	struct mc_msg_queue* tmp;
+
+	tmp = kmalloc(sizeof(struct mc_msg_queue), GFP_KERNEL);
+	if(!tmp){
+		printk("allocated wrong\n");
+		return MSG_RET_FAIL;
+	}
+
+	tmp->msg_data = kmalloc(sizeof(char)*(msg_size+1), GFP_KERNEL);
+	if(!tmp->msg_data){
+		kfree(tmp);
+		printk("allocated wrong\n");
+		return MSG_RET_FAIL;
+	}
+
+	strcpy(tmp->msg_data, msg_data);
+	tmp->msg_size = msg_size;
+
+	list_add_tail(&tmp->list, name_nid_dict);	
+
+	return MSG_RET_SUCCESS;
+}
+
+
+
+/* the msg data passed in should copy a new memory here, msg_data should point to a continous memory
+ *  * */
+unsigned int pop(char* msg_data, int* msg_size, struct list_head* name_nid_dict){
+	struct list_head* next = name_nid_dict->next;
+
+	struct mc_msg_queue* item = list_entry(next, struct mc_msg_queue, list);
+
+	strcpy(msg_data, item->msg_data);
+	*msg_size = item->msg_size;
+
+	list_del(&item->list);
+
+	kfree(item->msg_data);	
+	kfree(item);
+	name_nid_dict = next;
+
+	return MSG_RET_SUCCESS;
+}
+
+
+/*
+ * print api, for debug
+ */ 
+void print(struct list_head* name_nid_dict){
+	struct mc_msg_queue *pos = NULL;
+	list_for_each_entry(pos, name_nid_dict, list){
+		printk(pos->msg_data);
+		printk(" ");
+		printk("message data: %d\n", pos->msg_size);
+	}
+}
+
+void free_all(struct list_head* name_nid_dict){
+
+	struct list_head* cur=name_nid_dict->next;
+	while(cur != name_nid_dict){		
+		struct mc_msg_queue* item = list_entry(cur, struct mc_msg_queue, list);
+
+		struct list_head* tmp = cur->next;
+		list_del(cur);
+
+		cur = tmp;
+		kfree(item->msg_data);
+		kfree(item);
+	}
+}
+
+/*
+ * api for the message queue data structure in mComponent kernel side
+ */ 
+unsigned int mc_mq_open(char* mq_name, unsigned int max_size)
+{
+
+/*
+ *what if we already got a message queue with that name in the name map?	
+ */
+	unsigned long flags;
+	spin_lock_irqsave(&map_lock, flags);
+
+	struct name_mq_map *pos, *target = NULL;
+	list_for_each_entry(pos, &addr_map, list){
+
+		if(strcmp(mq_name, pos->mq_name)==0){
+			target = pos;		
+		}
+	}
+
+	if(target != NULL){
+		spin_unlock_irqrestore(&map_lock, flags);
+		return MSG_RET_FAIL;
+	}
+	
+	spin_unlock_irqrestore(&map_lock, flags);
+
+	struct name_mq_map* tmp;
+
+	tmp = kmalloc(sizeof(struct name_mq_map), GFP_KERNEL);
+	if(!tmp){
+		printk("allocated wrong\n");
+		return MSG_RET_FAIL;
+	}
+
+	strcpy(tmp->mq_name, mq_name);
+	tmp->max_size = max_size;
+	tmp->mq = kmalloc(sizeof(struct list_head), GFP_KERNEL);
+
+	INIT_LIST_HEAD(tmp->mq);	
+
+	/* init the lock */
+	spin_lock_init(&tmp->mq_lock);
+	spin_lock_irqsave(&map_lock, flags);
+
+	list_add_tail(&tmp->list, &addr_map);	
+
+	spin_unlock_irqrestore(&map_lock, flags);
+
+	kfree(tmp);
+	return MSG_RET_SUCCESS;
+}
+
+unsigned int mc_mq_close(char* mq_name){
+	unsigned long flags;
+	spin_lock_irqsave(&map_lock, flags);
+
+	/* make sure the message queue exists*/
+	struct name_mq_map *pos, *target = NULL;
+	list_for_each_entry(pos, &addr_map, list){
+
+		if(strcmp(mq_name, pos->mq_name)==0){
+			target = pos;		
+		}
+	}
+
+	if(target ==NULL){
+		spin_unlock_irqrestore(&map_lock, flags);	
+		return MSG_RET_FAIL;	
+	}
+
+	list_del(&target->list);
+
+	spin_unlock_irqrestore(&map_lock, flags);
+
+	/* possible leak
+         * what if message queue still gots some thing, then we free then
+         */
+	free_all(target->mq);
+	kfree(target->mq);
+	kfree(target);
+
+	return MSG_RET_SUCCESS;
+}
+
+
+unsigned int mc_mq_send(char *mq_name, char* msg_data, unsigned int msg_size){
+
+	/* find out where is our mq head pointer */
+	struct name_mq_map *pos, *target = NULL;
+	list_for_each_entry(pos, &addr_map, list){
+		if(strcmp(mq_name, pos->mq_name)==0){
+			target = pos;		
+		}
+	}
+	if(target != NULL){
+		/* spin lock acquire here */
+		unsigned long flags;
+
+		spin_lock_irqsave(&target->mq_lock,flags);
+		int res = append(msg_data, msg_size, target->mq);
+		spin_unlock_irqrestore(&target->mq_lock,flags);
+		return res;	
+	}
+	
+	/* 
+ 	 * message queue not found, return failed macro
+	 */
+	return MSG_RET_FAIL;
+}
+
+unsigned int mc_mq_receive(char *mq_name, char* msg_data, unsigned int* msg_size){
+
+
+	/* find out where is our mq head pointer */
+	struct name_mq_map *pos, *target = NULL;
+	list_for_each_entry(pos, &addr_map, list){
+		if(strcmp(mq_name, pos->mq_name)==0){
+			target = pos;		
+		}
+	}
+	if(target ==NULL){
+		return MSG_RET_FAIL;
+	}
+
+	/* spin lock acquire here */
+	unsigned long flags;
+
+	spin_lock_irqsave(&target->mq_lock,flags);
+	int res = pop(msg_data, msg_size, target->mq);
+	spin_unlock_irqrestore(&target->mq_lock,flags);
+
+	return res;
+}
+
+/*
+ * handling message queue api request in core.c
+ */
+
+void handle_mq_open_request(struct p2m_mqopen_payload* payload,
+	struct thpool_buffer *tb)
+{
+	ssize_t* retval;
+	retval = thpool_buffer_tx(tb);
+	tb_set_tx_size(tb, sizeof(*retval));
+
+	char* mq_name = payload->mq_name;
+	int max_size = payload->msg_size;
+	
+	/* mq open */
+	int res = mc_mq_open(mq_name, max_size);
+
+/* sync to gmm
+#ifdef CONFIG_GMM 
+	ssize_t result = read_mq_nid_from_gmm(kname);
+#endif
+*/
+	*retval = res;		
+}
+
+void handle_mq_send_request(struct p2m_mqsend_payload* payload,
+	struct thpool_buffer *tb)
+{
+	ssize_t* retval;
+	retval = thpool_buffer_tx(tb);
+	tb_set_tx_size(tb, sizeof(*retval));
+
+	/* debug */
+	char* mq_name = payload->mq_name;
+	char* mq_data = payload->msg;
+	int mq_size = payload->msg_size;
+
+	/* call mq send api from here! */
+	int res = mc_mq_send(mq_name, mq_data, strlen(mq_data));
+
+	/* return 0 means success!*/
+	*retval = res;
+}
+
+void handle_mq_receive_request(struct p2m_mqrecv_payload* payload,
+	struct thpool_buffer *tb)
+{
+ 	struct p2m_mqrecv_reply_struct* retval;
+	retval = thpool_buffer_tx(tb);
+	
+	char* msg = kmalloc(sizeof(char)*(MAX_FILENAME_LENGTH+1), GFP_KERNEL);	
+	if(!msg){
+		retval->ret = MSG_RET_FAIL;
+	}
+
+	int size;	
+	tb_set_tx_size(tb, sizeof(*retval));
+	
+	if(mc_mq_receive(payload->mq_name,msg,&size == MSG_RET_SUCCESS)){
+		strcpy(retval->mq_data, msg);
+		retval->ret = MSG_RET_SUCCESS;
+		kfree(msg);
+	}
+	else{
+		retval->ret = MSG_RET_FAIL;
+		kfree(msg);
+	}
+
+}
+
+void handle_mq_close_request(struct p2m_mqclose_payload* payload,
+	struct thpool_buffer *tb)
+{
+	
+	ssize_t* retval;
+	retval = thpool_buffer_tx(tb);
+
+	tb_set_tx_size(tb, sizeof(*retval));
+
+	*retval = mc_mq_close(payload->mq_name);
+
+}

--- a/managers/memory/handle_mq.c
+++ b/managers/memory/handle_mq.c
@@ -204,8 +204,7 @@ unsigned int mc_mq_send(char *mq_name, char* msg_data, unsigned int msg_size){
 
 unsigned int mc_mq_receive(char *mq_name, char* msg_data, unsigned int* msg_size){
 
-	spin_lock_irqsave(&target->mq_lock,flags);
-	
+
 	/* find out where is our mq head pointer */
 	struct name_mq_map *pos, *target = NULL;
 	list_for_each_entry(pos, &addr_map, list){
@@ -213,14 +212,14 @@ unsigned int mc_mq_receive(char *mq_name, char* msg_data, unsigned int* msg_size
 			target = pos;		
 		}
 	}
-	if(target ==NULL){
-		spin_unlock_irqrestore(&target->mq_lock,flags);
+	if(target ==NULL){	
 		return MSG_RET_FAIL;
 	}
 
 	/* spin lock acquire here */
 	unsigned long flags;
 
+	spin_lock_irqsave(&target->mq_lock,flags);	
 	int res = pop(msg_data, msg_size, target->mq);
 	spin_unlock_irqrestore(&target->mq_lock,flags);
 

--- a/managers/processor/message_queue.c
+++ b/managers/processor/message_queue.c
@@ -17,8 +17,7 @@
 
 #include "processor.h"
 #include <lego/fit_ibapi.h>
-
-#define MSG_RET_SUCCESS 0
+#include <lego/msg_q.h>
 
 SYSCALL_DEFINE4(mq_send, char*, name, unsigned long, name_size, unsigned long, msg_size, const char*, msg_data)
 {


### PR DESCRIPTION
This PR follows the work from last one:
https://github.com/yiying-zhang/Serverless-LegoOS/pull/1
which set up the syscall/opcode/interface in pComponent.

This PR contains the message queue implementation in mComponent kernel data structure, mainly in three parts:
1, message queue api handler, taking care of the pComponent request and send back what they need. in the form of handle_mq_*_request
2, message queue interface, in the form of mc_mq_send/receive/open/close, taking care of synchronization and calling low-level message queue data structure api. managing the name table(queue name - queue head pointer)
3, low level mq data structure api, in the form of append/pop/free_all, taking care of kernel memory management, ignorant of synchronization.


